### PR TITLE
added jupyter notebook version of run script

### DIFF
--- a/MESSAGEix_South_Africa.ipynb
+++ b/MESSAGEix_South_Africa.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MESSAGEix South Africa model\n",
+    "This notebook allows running the shale gas and carbon price scenarios described in the following manuscript:\n",
+    "> Orthofer et al. (2019) South Africa After Paris - Fracking Its Way to the NDCs? *Frontiers in Energy Research* 7(20). doi: [10.3389/fenrg.2019.00020](https://doi.org/10.3389/fenrg.2019.00020)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the utils package imported below is part of the message_ix_south_africa repository. Before importing them, it is necessary to add the path to the root directory of the repository's local copy to the environment variable \"PYTHONPATH\" and (re-)start jupyter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing required packages\n",
+    "from utils.run_scenarios import *\n",
+    "from utils.pp_db_to_xlsx import results_to_xlsx\n",
+    "from utils.pp_plot_emissions import plot_emissions\n",
+    "from utils.pp_plot_power_sector import plot_power_sector\n",
+    "from utils.pp_plot_heatmaps import plot_heatmap_comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define database and the baseline scenario\n",
+    "model = 'MESSAGE South Africa'\n",
+    "baseline = 'baseline'\n",
+    "database = 'message_sa'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# shale gas extraction costs (USDpMWh) & carbon costs (USDtCO2) to model\n",
+    "# shale_cost = list(range(1, 32, 2)) + [10000]\n",
+    "# carbon_cost = list(range(0, 62, 2))\n",
+    "shale_cost = [1, 10, 30, 1000]\n",
+    "carbon_cost = [0, 5, 15, 30]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run the scenarios\n",
+    "run_scenarios(model, baseline, database, shale_cost, carbon_cost)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run the postprocessing\n",
+    "results_to_xlsx(model, baseline, database, shale_cost, carbon_cost)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot ghg-emissions over the model horizon\n",
+    "plot_emissions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot energy and capacity mix of the power sector\n",
+    "plot_power_sector()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the scenario analysis heat maps - the variable 'years' indicates\n",
+    "# which years are presented in the plot\n",
+    "plot_heatmap_comparison(years=[2050])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
As an alternative to running the shale gas and carbon price scenarios via the script run.py I added a jupyter notebook version of the script that also briefly explains that PYTHONPATH needs to include the path to the root directory of the repository's local copy.